### PR TITLE
Remove setuptools higher bound

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 119b525c954df0d630e7bc7ef2cb7e50b406cca73a4caa823c43e49d58b52ebb
 
 build:
-  number: 1
+  number: 0
   noarch: python
   entry_points:
     - panel = panel.command:main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 119b525c954df0d630e7bc7ef2cb7e50b406cca73a4caa823c43e49d58b52ebb
 
 build:
-  number: 0
+  number: 1
   noarch: python
   entry_points:
     - panel = panel.command:main
@@ -20,7 +20,7 @@ requirements:
   host:
     - python >=3
     - pip
-    - setuptools >=42,<61
+    - setuptools >=42
     # These are also needed at build time.
     - pyct
     - bokeh >=2.4,<2.5


### PR DESCRIPTION
@philippjfr apparently the previous build didn't complete, `conda search panel` shows no `0.12.7` version available. The logs show that the build failed because the already installed version of setuptools is different than the one pinned in the recipe:
https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=481977&view=logs&j=656edd35-690f-5c53-9ba3-09c10d0bea97&t=e5c8ab1d-8ff9-5cae-b332-e15ae582ed2d&l=4179

I've removed the pin, I think it was there because of the issue with pyctdev and the new version of setuptools.