### PR TITLE
Require `setuptools` in `run` `<61`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,6 +32,7 @@ requirements:
     - bleach
   run:
     - python >=3
+    - setuptools >=42,<61
     - bokeh >=2.4,<2.5
     - markdown
     - param >=1.10.0


### PR DESCRIPTION
Should hopefully fix CI builds, which are failing atm.

Note didn't bump the build number as the builds are failing without this. So there are no packages to supersede.

We may also need to hot-fix past versions if this is needed there as well. For example ( https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/204 ).

cc @philippjfr @maximlt

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
