### PR TITLE
Add missing pinning for markdown-it-py.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 76ba4eac8bb178d032e3dd2a9c966cc8c088425f86eb567b06ed13baa84b4eb0
 
 build:
-  number: 0
+  number: 1
   noarch: python
   entry_points:
     - panel = panel.command:main
@@ -42,7 +42,7 @@ requirements:
     - requests
     - tqdm >=4.48.0
     - typing_extensions
-    - markdown-it-py
+    - markdown-it-py <3
     - linkify-it-py
     - mdit-py-plugins
   run_constrained:


### PR DESCRIPTION
It looks like in panel 1.1.0, `markdown-it-py` was pinned to `<3` [here](https://github.com/holoviz/panel/blob/b0ba5e31674c299fc42de2fcb55df725ef395c75/setup.py#LL109C19-L109C19). However, this pinning was not propagated to the conda recipe [here](https://github.com/conda-forge/panel-feedstock/blob/a5afb8c039bc211f88f469720ce3aaa154f3e89d/recipe/meta.yaml#L45). This causes `pip check` to fail in the build pipeline of arosics (see [here](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=726135&view=logs&jobId=d0d954b5-f111-5dc4-4d76-03b6c9d0cf7e&j=d0d954b5-f111-5dc4-4d76-03b6c9d0cf7e&t=841356e0-85bb-57d8-dbbc-852e683d1642)) because conda installs `markdown-it-py` 3.0.0 and `pip check` looks at the PyPI requirements of the package which have the `<3` pinning.

This PR adds the missing pinning.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
