### PR TITLE
Remove pinning for markdown-it-py (not needed anymore).

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 956f053f2b3674516c0fe928c27bf2e7080e0ee669dd3e05f27b9bad19cdf24f
 
 build:
-  number: 0
+  number: 1
   noarch: python
   entry_points:
     - panel = panel.command:main
@@ -42,7 +42,7 @@ requirements:
     - requests
     - tqdm >=4.48.0
     - typing_extensions
-    - markdown-it-py <3
+    - markdown-it-py
     - linkify-it-py
     - mdit-py-plugins
   run_constrained:


### PR DESCRIPTION
The pinning was added in panel 1.1.0 and is not needed anymore in 1.1.1.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
